### PR TITLE
SVP AttributeError

### DIFF
--- a/svptreectrl.py
+++ b/svptreectrl.py
@@ -7627,7 +7627,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             flags = TREE_HITTEST_NOWHERE
             return None, flags
 
-        point = self.CalcUnscrolledPosition(*point)
+        point = wx.Point(self.CalcUnscrolledPosition(*point))
         hit, flags = self._anchor.HitTest(point, self, flags, 0)
 
         if hit == None:


### PR DESCRIPTION
self.CalcUnscrolledPosition(*point) is returning two variables,  i.e. x, y  using wxPoint() to construct the point again.